### PR TITLE
fix: handle tw=0

### DIFF
--- a/lua/neorg/modules/external/conceal-wrap/module.lua
+++ b/lua/neorg/modules/external/conceal-wrap/module.lua
@@ -90,6 +90,9 @@ module.public.format = function()
         local new_lines = {}
 
         local width = vim.bo.textwidth
+        if width == 0 then
+            width = 80 -- this is the value the built-in formatter defaults to when tw=0
+        end
 
         -- account for breakindent
         local indent = vim.fn.eval(vim.bo.indentexpr)


### PR DESCRIPTION
when textwidth was set to 0, we were using 5 width (which is just an arbitrary min width that I set), instead of falling back to a reasonable default width.

Now fall back to 80 when tw=0. This is the same value that vim's inbuilt formatter uses (with `gwip` for example).
